### PR TITLE
Improve collision

### DIFF
--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/Utils.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/Utils.java
@@ -67,4 +67,22 @@ public final class Utils {
 
         return hx * hx + hy * hy <= cr * cr;
     }
+
+    public static boolean centerSquareCollision(float x1, float y1, float h1,
+                                                float x2, float y2, float h2) {
+        // +------+
+        // |      | x, y = the center
+        // |      | h    = side length / 2 = apothem
+        // +------+
+        //
+        // squares do not rotate just check distance between
+
+        // return x1 - h1 < x2 + h2
+        //     && x1 + h1 > x2 - h2
+        //     && y1 - h1 < y2 + h2
+        //     && y1 + h1 > y2 - h1;
+        final float dist = h1 + h2;
+        return Math.abs(x1 - x2) < dist
+            && Math.abs(y1 - y2) < dist;
+    }
 }

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/Utils.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/Utils.java
@@ -85,4 +85,17 @@ public final class Utils {
         return Math.abs(x1 - x2) < dist
             && Math.abs(y1 - y2) < dist;
     }
+
+    public static boolean fastCircleCollision(float x1, float y1, float r1,
+                                              float x2, float y2, float r2) {
+        // Only perform accurate collision if both circles collide as squares
+        if (centerSquareCollision(x1, y1, r1, x2, y2, r2)) {
+            // Accurate collision check
+            final float dx = x1 - x2;
+            final float dy = y1 - y2;
+            final float dr = r1 + r2;
+            return dx * dx + dy * dy < dr * dr;
+        }
+        return false;
+    }
 }

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/Utils.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/Utils.java
@@ -98,4 +98,8 @@ public final class Utils {
         }
         return false;
     }
+
+    public static boolean isPtOutOfScreen(final float x, final float y, final int w, final int h) {
+        return !(x > 0 && y > 0 && x < w && y < h);
+    }
 }

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/IEnemy.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/IEnemy.java
@@ -30,6 +30,8 @@ import org.atoiks.games.framework2d.IUpdate;
 import org.atoiks.games.nappou2.graphics.IEnemyRenderer;
 import org.atoiks.games.nappou2.graphics.ColorEnemyRenderer;
 
+import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
+
 public abstract class IEnemy implements ICollidable, IRender, IUpdate, Serializable {
 
     private static final long serialVersionUID = 8123472652L;
@@ -67,11 +69,20 @@ public abstract class IEnemy implements ICollidable, IRender, IUpdate, Serializa
     }
 
     @Override
-    public boolean collidesWith(float x1, float y1, float r1) {
-        final float dx = x1 - getX();
-        final float dy = y1 - getY();
-        final float dr = r1 + getR();
-        return dx * dx + dy * dy < dr * dr;
+    public boolean collidesWith(final float x1, final float y1, final float r1) {
+        final float x = getX();
+        final float y = getY();
+        final float r = getR();
+        // Only perform accurate collision if two both circles collide as
+        // squares.
+        if (centerSquareCollision(x, y, r, x1, y1, r1)) {
+            // Accurate collision checks distance between the circles.
+            final float dx = x1 - x;
+            final float dy = y1 - y;
+            final float dr = r1 + r;
+            return dx * dx + dy * dy < dr * dr;
+        }
+        return false;
     }
 
     @Override

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/IEnemy.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/IEnemy.java
@@ -30,7 +30,7 @@ import org.atoiks.games.framework2d.IUpdate;
 import org.atoiks.games.nappou2.graphics.IEnemyRenderer;
 import org.atoiks.games.nappou2.graphics.ColorEnemyRenderer;
 
-import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
+import static org.atoiks.games.nappou2.Utils.fastCircleCollision;
 
 public abstract class IEnemy implements ICollidable, IRender, IUpdate, Serializable {
 
@@ -70,19 +70,7 @@ public abstract class IEnemy implements ICollidable, IRender, IUpdate, Serializa
 
     @Override
     public boolean collidesWith(final float x1, final float y1, final float r1) {
-        final float x = getX();
-        final float y = getY();
-        final float r = getR();
-        // Only perform accurate collision if two both circles collide as
-        // squares.
-        if (centerSquareCollision(x, y, r, x1, y1, r1)) {
-            // Accurate collision checks distance between the circles.
-            final float dx = x1 - x;
-            final float dy = y1 - y;
-            final float dr = r1 + r;
-            return dx * dx + dy * dy < dr * dr;
-        }
-        return false;
+        return fastCircleCollision(getX(), getY(), getR(), x1, y1, r1);
     }
 
     @Override

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/IShield.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/IShield.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import org.atoiks.games.framework2d.IRender;
 import org.atoiks.games.framework2d.IUpdate;
 
-public interface IShield extends ICollidable, IRender, IUpdate, Serializable {
+public interface IShield extends IRender, IUpdate, Serializable {
 
     public float getX();
     public float getY();

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/Beam.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/Beam.java
@@ -25,6 +25,7 @@ import org.atoiks.games.framework2d.IGraphics;
 
 import org.atoiks.games.nappou2.entities.IBullet;
 
+import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
 import static org.atoiks.games.nappou2.Utils.intersectSegmentCircle;
 import static org.atoiks.games.nappou2.TrigConstants.*;
 
@@ -107,12 +108,20 @@ public final class Beam extends IBullet {
     }
 
     @Override
-    public boolean collidesWith(final float x, final float y, final float r) {
-        // Manual loop unrolling
-        return intersectSegmentCircle(dest[0], dest[1], dest[2], dest[3], x, y, r)
-            || intersectSegmentCircle(dest[2], dest[3], dest[4], dest[5], x, y, r)
-            || intersectSegmentCircle(dest[4], dest[5], dest[6], dest[7], x, y, r)
-            || intersectSegmentCircle(dest[6], dest[7], dest[0], dest[1], x, y, r);
+    public boolean collidesWith(final float x1, final float y1, final float r1) {
+        // Only perform accurate collision if the square formed by center
+        // point (x, y) with apothem collides with the circle also
+        // approximated as a square with the apothem being its radius.
+        final float apothem = Math.max(halfThickness, length * 2) / 2;
+        if (centerSquareCollision(x, y, apothem, x1, y1, r1)) {
+            // Accurate collision checks if any of the sides intersect with
+            // the circle.
+            return intersectSegmentCircle(dest[0], dest[1], dest[2], dest[3], x1, y1, r1)
+                || intersectSegmentCircle(dest[2], dest[3], dest[4], dest[5], x1, y1, r1)
+                || intersectSegmentCircle(dest[4], dest[5], dest[6], dest[7], x1, y1, r1)
+                || intersectSegmentCircle(dest[6], dest[7], dest[0], dest[1], x1, y1, r1);
+        }
+        return false;
     }
 
     @Override

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/Beam.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/Beam.java
@@ -25,6 +25,7 @@ import org.atoiks.games.framework2d.IGraphics;
 
 import org.atoiks.games.nappou2.entities.IBullet;
 
+import static org.atoiks.games.nappou2.Utils.isPtOutOfScreen;
 import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
 import static org.atoiks.games.nappou2.Utils.intersectSegmentCircle;
 import static org.atoiks.games.nappou2.TrigConstants.*;
@@ -130,9 +131,5 @@ public final class Beam extends IBullet {
             && isPtOutOfScreen(dest[2], dest[3], w, h)
             && isPtOutOfScreen(dest[4], dest[5], w, h)
             && isPtOutOfScreen(dest[6], dest[7], w, h);
-    }
-
-    private static boolean isPtOutOfScreen(final float x, final float y, final int w, final int h) {
-        return !(x > 0 && y > 0 && x < w && y < h);
     }
 }

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/PointBullet.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/PointBullet.java
@@ -24,6 +24,8 @@ import org.atoiks.games.framework2d.IGraphics;
 
 import org.atoiks.games.nappou2.entities.IBullet;
 
+import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
+
 public final class PointBullet extends IBullet {
 
     private static final long serialVersionUID = 3928242215L;
@@ -81,11 +83,17 @@ public final class PointBullet extends IBullet {
     }
 
     @Override
-    public boolean collidesWith(float x1, float y1, float r1) {
-        final float dx = x1 - x;
-        final float dy = y1 - y;
-        final float dr = r1 + r;
-        return dx * dx + dy * dy < dr * dr;
+    public boolean collidesWith(final float x1, final float y1, final float r1) {
+        // Only perform accurate collision if two both circles collide as
+        // squares.
+        if (centerSquareCollision(x, y, r, x1, y1, r1)) {
+            // Accurate collision checks distance between the circles.
+            final float dx = x1 - x;
+            final float dy = y1 - y;
+            final float dr = r1 + r;
+            return dx * dx + dy * dy < dr * dr;
+        }
+        return false;
     }
 
     @Override

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/PointBullet.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/PointBullet.java
@@ -24,7 +24,7 @@ import org.atoiks.games.framework2d.IGraphics;
 
 import org.atoiks.games.nappou2.entities.IBullet;
 
-import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
+import static org.atoiks.games.nappou2.Utils.fastCircleCollision;
 
 public final class PointBullet extends IBullet {
 
@@ -84,16 +84,7 @@ public final class PointBullet extends IBullet {
 
     @Override
     public boolean collidesWith(final float x1, final float y1, final float r1) {
-        // Only perform accurate collision if two both circles collide as
-        // squares.
-        if (centerSquareCollision(x, y, r, x1, y1, r1)) {
-            // Accurate collision checks distance between the circles.
-            final float dx = x1 - x;
-            final float dy = y1 - y;
-            final float dr = r1 + r;
-            return dx * dx + dy * dy < dr * dr;
-        }
-        return false;
+        return fastCircleCollision(x, y, r, x1, y1, r1);
     }
 
     @Override

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/TrackPointBullet.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/TrackPointBullet.java
@@ -25,6 +25,8 @@ import org.atoiks.games.framework2d.IGraphics;
 import org.atoiks.games.nappou2.entities.Game;
 import org.atoiks.games.nappou2.entities.IBullet;
 
+import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
+
 public final class TrackPointBullet extends IBullet {
 
     private static final long serialVersionUID = -1696891011951230605L;
@@ -63,11 +65,17 @@ public final class TrackPointBullet extends IBullet {
     }
 
     @Override
-    public boolean collidesWith(float x1, float y1, float r1) {
-        final float dx = x1 - x;
-        final float dy = y1 - y;
-        final float dr = r1 + r;
-        return dx * dx + dy * dy < dr * dr;
+    public boolean collidesWith(final float x1, final float y1, final float r1) {
+        // Only perform accurate collision if two both circles collide as
+        // squares.
+        if (centerSquareCollision(x, y, r, x1, y1, r1)) {
+            // Accurate collision checks distance between the circles.
+            final float dx = x1 - x;
+            final float dy = y1 - y;
+            final float dr = r1 + r;
+            return dx * dx + dy * dy < dr * dr;
+        }
+        return false;
     }
 
     @Override

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/TrackPointBullet.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/TrackPointBullet.java
@@ -25,7 +25,7 @@ import org.atoiks.games.framework2d.IGraphics;
 import org.atoiks.games.nappou2.entities.Game;
 import org.atoiks.games.nappou2.entities.IBullet;
 
-import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
+import static org.atoiks.games.nappou2.Utils.fastCircleCollision;
 
 public final class TrackPointBullet extends IBullet {
 
@@ -66,16 +66,7 @@ public final class TrackPointBullet extends IBullet {
 
     @Override
     public boolean collidesWith(final float x1, final float y1, final float r1) {
-        // Only perform accurate collision if two both circles collide as
-        // squares.
-        if (centerSquareCollision(x, y, r, x1, y1, r1)) {
-            // Accurate collision checks distance between the circles.
-            final float dx = x1 - x;
-            final float dy = y1 - y;
-            final float dr = r1 + r;
-            return dx * dx + dy * dy < dr * dr;
-        }
-        return false;
+        return fastCircleCollision(x, y, r, x1, y1, r1);
     }
 
     @Override

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/TrackPolygonBullet.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/bullet/TrackPolygonBullet.java
@@ -20,11 +20,15 @@ package org.atoiks.games.nappou2.entities.bullet;
 
 import java.awt.Color;
 
+import java.util.Arrays;
+
 import org.atoiks.games.framework2d.IGraphics;
 
 import org.atoiks.games.nappou2.entities.Game;
 import org.atoiks.games.nappou2.entities.IBullet;
 
+import static org.atoiks.games.nappou2.Utils.isPtOutOfScreen;
+import static org.atoiks.games.nappou2.Utils.centerSquareCollision;
 import static org.atoiks.games.nappou2.Utils.intersectSegmentCircle;
 
 public final class TrackPolygonBullet extends IBullet {
@@ -45,20 +49,47 @@ public final class TrackPolygonBullet extends IBullet {
     private float time;
     private boolean moving;
 
+    private float boundX, boundY, boundR;
+
     public TrackPolygonBullet(float[] coords, Game game, float pathScale, float moveTime, float delay) {
-        this.coords = coords;
         this.game = game;
         this.scale = pathScale;
         this.moveTime = moveTime;
         this.delay = delay;
+
+        final float[] copy = Arrays.copyOf(coords, coords.length);
+        this.coords = copy;
+
+        // Reshape the bounding box here
+        float x1 = Float.POSITIVE_INFINITY;
+        float y1 = Float.POSITIVE_INFINITY;
+        float x2 = Float.NEGATIVE_INFINITY;
+        float y2 = Float.NEGATIVE_INFINITY;
+        for (int i = 0; i < coords.length; i += 2) {
+            final float x = coords[i];
+            final float y = coords[i + 1];
+            if (x < x1) x1 = x;
+            if (x > x2) x2 = x;
+            if (y < y1) y1 = y;
+            if (y > y2) y2 = y;
+        }
+
+        // boundX boundY is center of bounding box
+        boundX = (x1 + x2) / 2;
+        boundY = (y1 + y2) / 2;
+        // + 4 just in case for some reason the shape is actually not contained
+        // properly within the bounding box
+        boundR = Math.max(x2 - x1, y2 - y1) / 2 + 4;
     }
 
     @Override
     public void translate(float dx, float dy) {
         for (int i = 0; i < coords.length; i += 2) {
-            coords[i + 0] += dx;
+            coords[i] += dx;
             coords[i + 1] += dy;
         }
+        boundX += dx;
+        boundY += dy;
     }
 
     @Override
@@ -110,13 +141,15 @@ public final class TrackPolygonBullet extends IBullet {
 
     @Override
     public boolean collidesWith(float x1, float y1, float r1) {
-        for (int i = 0; i < coords.length; i += 2) {
-            final float startX = coords[i];
-            final float startY = coords[i + 1];
-            final float endX   = coords[(i + 2) % coords.length];
-            final float endY   = coords[(i + 3) % coords.length];
-            if (intersectSegmentCircle(startX, startY, endX, endY, x1, y1, r1)) {
-                return true;
+        if (centerSquareCollision(boundX, boundY, boundR, x1, y1, r1)) {
+            for (int i = 0; i < coords.length; i += 2) {
+                final float startX = coords[i];
+                final float startY = coords[i + 1];
+                final float endX   = coords[(i + 2) % coords.length];
+                final float endY   = coords[(i + 3) % coords.length];
+                if (intersectSegmentCircle(startX, startY, endX, endY, x1, y1, r1)) {
+                    return true;
+                }
             }
         }
         return false;
@@ -125,17 +158,10 @@ public final class TrackPolygonBullet extends IBullet {
     @Override
     public boolean isOutOfScreen(final int w, final int h) {
         for (int i = 0; i < coords.length; i += 2) {
-            if (pointIsOutOfScreen(coords[i], coords[i + 1])) {
+            if (isPtOutOfScreen(coords[i], coords[i + 1], w, h)) {
                 return true;
             }
         }
         return false;
-    }
-
-    private static boolean pointIsOutOfScreen(float x, float y) {
-        return (x < -SCREEN_EDGE_BUFFER)
-            || (x > SCREEN_EDGE_BUFFER)
-            || (y < -SCREEN_EDGE_BUFFER)
-            || (y > SCREEN_EDGE_BUFFER);
     }
 }

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/shield/NullShield.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/shield/NullShield.java
@@ -27,16 +27,6 @@ public class NullShield implements IShield {
     private static final long serialVersionUID = -6024720306180805901L;
 
     @Override
-    public boolean collidesWith(float x, float y, float r) {
-        return false;
-    }
-
-    @Override
-    public boolean isOutOfScreen(int width, int height) {
-        return false;
-    }
-
-    @Override
     public void render(IGraphics g) {
         // Do nothing
     }

--- a/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/shield/TimeBasedShield.java
+++ b/Nappou-2/src/main/java/org/atoiks/games/nappou2/entities/shield/TimeBasedShield.java
@@ -103,23 +103,6 @@ public abstract class TimeBasedShield implements IShield {
     }
 
     @Override
-    public boolean isOutOfScreen(int width, int height) {
-        // Being out of screen does not qualify it for deallocation
-        return false;
-    }
-
-    @Override
-    public boolean collidesWith(float x1, float y1, float r1) {
-        if (active) {
-            final float dx = x1 - x;
-            final float dy = y1 - y;
-            final float dr = r1 + r;
-            return dx * dx + dy * dy < dr * dr;
-        }
-        return false;
-    }
-
-    @Override
     public boolean isReady() {
         return time > timeout + reloadTime;
     }


### PR DESCRIPTION
Tested with 

```java
final int BULLETS = 500000;
final float TIMES = 200;
final ArrayList<IBullet> list = new ArrayList<>(BULLETS);
for (int i = 0; i < BULLETS; ++i) {
    list.add(new PointBullet(i + 5, 5 - i, 10, 3, 6));
    list.add(new Beam(i + 15, 15 - i, 10, 7.5f, 3.14f, 6));
}

long sum = 0;
for (int times = 0; times < TIMES; ++times) {
    for (int i = 0; i < list.size(); ++i) list.get(i).update(0.001f);

    final long now = System.currentTimeMillis();
    for (int i = 0; i < list.size(); ++i) {
        if (list.get(i).collidesWith(0, 0, 5)) {
            list.remove(i);
            if (--i < -1) break;
        }
    }
    final long elapsed = System.currentTimeMillis() - now;
    sum += elapsed;
}
System.out.println("...sum " + sum + "ms");
System.out.println("...avg " + (sum / TIMES) + "ms");
```

and it went from 19ms to 10.5ms