### PR TITLE
Remove redundant start calls

### DIFF
--- a/src/main/java/org/atoiks/games/nappou2/levels/level1/PrebossDialog.java
+++ b/src/main/java/org/atoiks/games/nappou2/levels/level1/PrebossDialog.java
@@ -63,7 +63,6 @@ public final class PrebossDialog extends AbstractDialogState {
         if (ResourceManager.<GameConfig>get("./game.cfg").bgm) {
             final Clip bgm = ResourceManager.get("/music/Level_One_Boss.wav");
             bgm.setMicrosecondPosition(0);
-            bgm.start();
             bgm.setLoopPoints(BOSS_LOOP, -1);
             bgm.loop(Clip.LOOP_CONTINUOUSLY);
         }

--- a/src/main/java/org/atoiks/games/nappou2/levels/level1/Stage.java
+++ b/src/main/java/org/atoiks/games/nappou2/levels/level1/Stage.java
@@ -72,7 +72,6 @@ public final class Stage implements LevelState {
         bgm = ResourceManager.get("/music/Level_One.wav");
         if (cfg.bgm) {
             bgm.setMicrosecondPosition(0);
-            bgm.start();
             bgm.setLoopPoints(LEVEL_LOOP, -1);
             bgm.loop(Clip.LOOP_CONTINUOUSLY);
         }

--- a/src/main/java/org/atoiks/games/nappou2/levels/level2/PrebossDialog.java
+++ b/src/main/java/org/atoiks/games/nappou2/levels/level2/PrebossDialog.java
@@ -64,7 +64,6 @@ import static org.atoiks.games.nappou2.entities.Message.HorizontalAlignment;
         if (ResourceManager.<GameConfig>get("./game.cfg").bgm) {
             final Clip bgm = ResourceManager.get("/music/Broken_Soul.wav");
             bgm.setMicrosecondPosition(0);
-            bgm.start();
             bgm.loop(Clip.LOOP_CONTINUOUSLY);
         }
     }

--- a/src/main/java/org/atoiks/games/nappou2/levels/tutorial/BossWave.java
+++ b/src/main/java/org/atoiks/games/nappou2/levels/tutorial/BossWave.java
@@ -51,7 +51,6 @@ import org.atoiks.games.nappou2.entities.enemy.CAITutorial;
         if (ResourceManager.<GameConfig>get("./game.cfg").bgm) {
             final Clip bgm = ResourceManager.get("/music/Unlocked.wav");
             bgm.setMicrosecondPosition(0);
-            bgm.start();
             bgm.loop(Clip.LOOP_CONTINUOUSLY);
         }
 

--- a/src/main/java/org/atoiks/games/nappou2/levels/tutorial/Preface.java
+++ b/src/main/java/org/atoiks/games/nappou2/levels/tutorial/Preface.java
@@ -100,7 +100,6 @@ public final class Preface implements LevelState {
         if (cfg.bgm) {
             final Clip bgm = ResourceManager.get("/music/Awakening.wav");
             bgm.setMicrosecondPosition(0);
-            bgm.start();
             bgm.loop(Clip.LOOP_CONTINUOUSLY);
         }
 

--- a/src/main/java/org/atoiks/games/nappou2/scenes/ConfigScene.java
+++ b/src/main/java/org/atoiks/games/nappou2/scenes/ConfigScene.java
@@ -105,7 +105,6 @@ public final class ConfigScene extends OptionSelectScene {
         switch (selector) {
             case 0:
                 if ((config.bgm = newValue)) {
-                    bgm.start();
                     bgm.loop(Clip.LOOP_CONTINUOUSLY);
                 } else {
                     bgm.stop();

--- a/src/main/java/org/atoiks/games/nappou2/scenes/TitleScene.java
+++ b/src/main/java/org/atoiks/games/nappou2/scenes/TitleScene.java
@@ -79,7 +79,6 @@ public final class TitleScene extends OptionSelectScene {
         // Enter only deals with scenes that play different songs!
         if (ResourceManager.<GameConfig>get("./game.cfg").bgm) {
             bgm.setMicrosecondPosition(0);
-            bgm.start();
             bgm.loop(Clip.LOOP_CONTINUOUSLY);
         }
 


### PR DESCRIPTION
Apparently `loop(int)` starts the clips themselves, so no need to call `start()`.